### PR TITLE
Fix compile stopping

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Forked it if I add any custom board level hardware emulation in future. 
+Forked it so that I can add any custom board level hardware emulation in future. 
 
 ===========
 OVERVIEW

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+Forked it if I add any custom board level hardware emulation in future. 
+
 ===========
 OVERVIEW
 ===========

--- a/hw/arm/bcm2836.c
+++ b/hw/arm/bcm2836.c
@@ -30,13 +30,13 @@ static const BCM283XInfo bcm283x_socs[] = {
     {
         .name = TYPE_BCM2835,
         .cpu_type = ARM_CPU_TYPE_NAME("arm1176"),
-        .core_count = 1,
+        .core_count = BCM2835_NCPUS,
         .peri_base = 0x20000000,
     },
     {
         .name = TYPE_BCM2836,
         .cpu_type = ARM_CPU_TYPE_NAME("cortex-a7"),
-	    .core_count = 4,
+	    .core_count = BCM283X_NCPUS,
         .peri_base = 0x3f000000,
         .ctrl_base = 0x40000000,
         .clusterid = 0xf,
@@ -45,7 +45,7 @@ static const BCM283XInfo bcm283x_socs[] = {
     {
         .name = TYPE_BCM2837,
         .cpu_type = ARM_CPU_TYPE_NAME("cortex-a53"),
-	.core_count = 4,
+	    .core_count = BCM283X_NCPUS,
         .peri_base = 0x3f000000,
         .ctrl_base = 0x40000000,
         .clusterid = 0x0,

--- a/hw/arm/raspi.c
+++ b/hw/arm/raspi.c
@@ -104,7 +104,7 @@ static const char *board_soc_type(uint32_t board_rev)
 static int cores_count(uint32_t board_rev)
 {
     static const int soc_cores_count[] = {
-        NULL, BCM283X_NCPUS, BCM283X_NCPUS, 1
+        0, BCM283X_NCPUS, BCM283X_NCPUS, BCM2835_NCPUS
     };
     int proc_id = board_processor_id(board_rev);
 

--- a/include/hw/arm/bcm2836.h
+++ b/include/hw/arm/bcm2836.h
@@ -19,6 +19,7 @@
 #define TYPE_BCM283X "bcm283x"
 #define BCM283X(obj) OBJECT_CHECK(BCM283XState, (obj), TYPE_BCM283X)
 
+#define BCM2835_NCPUS 1
 #define BCM283X_NCPUS 4
 
 /* These type names are for specific SoCs; other than instantiating


### PR DESCRIPTION
$make gives following problem,

```
  CC      aarch64-softmmu/hw/arm/raspi.o
/home/khan/qemu-build/qemu/hw/arm/raspi.c: In function ‘cores_count’:
/home/khan/qemu-build/qemu/hw/arm/raspi.c:107:9: error: initialization of ‘int’ from ‘void *’ makes integer from pointer without a cast [-Werror=int-conversion]
  107 |         NULL, BCM283X_NCPUS, BCM283X_NCPUS, 1
      |         ^~~~
/home/khan/qemu-build/qemu/hw/arm/raspi.c:107:9: note: (near initialization for ‘soc_cores_count[0]’)
cc1: all warnings being treated as errors
make[1]: *** [/home/khan/qemu-build/qemu/rules.mak:69: hw/arm/raspi.o] Error 1
make: *** [Makefile:527: aarch64-softmmu/all] Error 2
```